### PR TITLE
Return only new attributes when applying block supports

### DIFF
--- a/includes/main.php
+++ b/includes/main.php
@@ -78,11 +78,13 @@ function register_attribute( $block_type ) {
  * @return array Block margin CSS classes and inline styles.
  */
 function apply( $block_type, $block_attributes ) {
+	$attributes = array();
+
 	$has_block_margin = array_key_exists( 'margin', $block_attributes );
 
 	if ( $has_block_margin ) {
-		$block_attributes['class'] = sprintf( 'has-%s-margin-top', $block_attributes['margin'] );
+		$attributes['class'] = sprintf( 'has-%s-margin-top', $block_attributes['margin'] );
 	}
 
-	return $block_attributes;
+	return $attributes;
 }


### PR DESCRIPTION
When WordPress defers to Block Margin via `apply_block_supports()`, it expects only new attributes to be returned rather than those it has already built for the block.

We only alter the class name, so an array with just that string value should be returned.